### PR TITLE
fix(NotSuccess): exclude `SUCCESS`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use crate::status;
+use core::convert::TryInto;
 use r_efi::efi;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -24,16 +25,13 @@ impl<T> Error<T> {
 
     pub(crate) fn from_status_and_value(status: efi::Status, value: T) -> Self {
         Self {
-            status: status.into(),
+            status: status.try_into().expect("`SUCCESS` is passed."),
             value,
         }
     }
 }
 impl From<efi::Status> for Error<()> {
     fn from(s: efi::Status) -> Self {
-        Self {
-            status: s.into(),
-            value: (),
-        }
+        Self::from_status_and_value(s, ())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,8 +22,11 @@ impl<T> Error<T> {
         }
     }
 
-    pub(crate) fn from_status_and_value(status: status::NotSuccess, value: T) -> Self {
-        Self { status, value }
+    pub(crate) fn from_status_and_value(status: efi::Status, value: T) -> Self {
+        Self {
+            status: status.into(),
+            value,
+        }
     }
 }
 impl From<efi::Status> for Error<()> {

--- a/src/protocols/media/file.rs
+++ b/src/protocols/media/file.rs
@@ -55,10 +55,8 @@ impl<'a> File<'a> {
 
         match r {
             Status::SUCCESS => Ok(()),
-            Status::BUFFER_TOO_SMALL => {
-                Err(crate::Error::from_status_and_value(r.into(), Some(buf_len)))
-            }
-            _ => Err(crate::Error::from_status_and_value(r.into(), None)),
+            Status::BUFFER_TOO_SMALL => Err(crate::Error::from_status_and_value(r, Some(buf_len))),
+            _ => Err(crate::Error::from_status_and_value(r, None)),
         }
     }
 

--- a/src/service/boot.rs
+++ b/src/service/boot.rs
@@ -97,7 +97,7 @@ impl<'a> Boot<'a> {
             }))
         } else {
             Err(crate::Error::from_status_and_value(
-                s.into(),
+                s,
                 if s == efi::Status::BUFFER_TOO_SMALL {
                     Some(memory_map_size)
                 } else {

--- a/src/system_table.rs
+++ b/src/system_table.rs
@@ -54,10 +54,7 @@ impl SystemTable {
         if s == efi::Status::SUCCESS {
             Ok(())
         } else {
-            Err(crate::Error::from_status_and_value(
-                s.into(),
-                (self, image_handle),
-            ))
+            Err(crate::Error::from_status_and_value(s, (self, image_handle)))
         }
     }
 


### PR DESCRIPTION
Taking `efi::Status` instead of `NotSuccess` reduces the number of
lines.